### PR TITLE
Add Error struct type and tests, enabling easier error return checking

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,18 @@
+package zfs
+
+import (
+	"fmt"
+)
+
+// Error is an error which is returned when the `zfs` or `zpool` shell
+// commands return with a non-zero exit code.
+type Error struct {
+	Err    error
+	Debug  string
+	Stderr string
+}
+
+// Error returns the string representation of an Error.
+func (e Error) Error() string {
+	return fmt.Sprintf("%s: %q => %s", e.Err, e.Debug, e.Stderr)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,37 @@
+package zfs
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	var tests = []struct {
+		err    error
+		debug  string
+		stderr string
+	}{
+		// Empty error
+		{nil, "", ""},
+		// Typical error
+		{errors.New("exit status foo"), "/sbin/foo bar qux", "command not found"},
+		// Quoted error
+		{errors.New("exit status quoted"), "\"/sbin/foo\" bar qux", "\"some\" 'random' `quotes`"},
+	}
+
+	for _, test := range tests {
+		// Generate error from tests
+		zErr := Error{
+			Err:    test.err,
+			Debug:  test.debug,
+			Stderr: test.stderr,
+		}
+
+		// Verify output format is consistent, so that any changes to the
+		// Error method must be reflected by the test
+		if str := zErr.Error(); str != fmt.Sprintf("%s: %q => %s", test.err, test.debug, test.stderr) {
+			t.Fatalf("unexpected Error string: %v", str)
+		}
+	}
+}

--- a/utils.go
+++ b/utils.go
@@ -40,7 +40,11 @@ func (c *command) Run(arg ...string) ([][]string, error) {
 	err := cmd.Run()
 
 	if err != nil {
-		return nil, fmt.Errorf("%s: '%s' => %s", err, debug, stderr.String())
+		return nil, &Error{
+			Err:    err,
+			Debug:  debug,
+			Stderr: stderr.String(),
+		}
 	}
 
 	// assume if you passed in something for stdout, that you know what to do with it


### PR DESCRIPTION
Closes #9.

In the future, additional error checking helpers could be added using this struct, such as something like:

``` go
func IsZpoolExists(err error) bool
```

Which could easily indicate an error returned on zpool creation failure, due to a zpool already existing with the same name.
