### PR TITLE
Add zpool state constants, for easier health checking

### DIFF
--- a/zpool.go
+++ b/zpool.go
@@ -1,5 +1,17 @@
 package zfs
 
+// ZFS zpool states, which can indicate if a pool is online, offline,
+// degraded, etc.  More information regarding zpool states can be found here:
+// https://docs.oracle.com/cd/E19253-01/819-5461/gamno/index.html.
+const (
+	ZpoolOnline   = "ONLINE"
+	ZpoolDegraded = "DEGRADED"
+	ZpoolFaulted  = "FAULTED"
+	ZpoolOffline  = "OFFLINE"
+	ZpoolUnavail  = "UNAVAIL"
+	ZpoolRemoved  = "REMOVED"
+)
+
 // Zpool is a ZFS zpool.  A pool is a top-level structure in ZFS, and can
 // contain many descendent datasets.
 type Zpool struct {


### PR DESCRIPTION
Closes #14.

I'm not entirely sure about adding a `zpool.IsHealthy()` method or similar, since a zpool could technically be in a state like `DEGRADED` or `OFFLINE`, and still be "healthy", even with some functionality unavailable.

For now, I think just adding these constants is a good idea.
