### PR TITLE
Add dataset type constants, for easier type checking

### DIFF
--- a/zfs.go
+++ b/zfs.go
@@ -9,6 +9,14 @@ import (
 	"strings"
 )
 
+// ZFS dataset types, which can indicate if a dataset is a filesystem,
+// snapshot, or volume.
+const (
+	DatasetFilesystem = "filesystem"
+	DatasetSnapshot   = "snapshot"
+	DatasetVolume     = "volume"
+)
+
 // Dataset is a ZFS dataset.  A dataset could be a clone, filesystem, snapshot,
 // or volume.  The Type struct member can be used to determine a dataset's type.
 //
@@ -44,21 +52,21 @@ func Datasets(filter string) ([]*Dataset, error) {
 // A filter argument may be passed to select a snapshot with the matching name,
 // or empty string ("") may be used to select all snapshots.
 func Snapshots(filter string) ([]*Dataset, error) {
-	return listByType("snapshot", filter)
+	return listByType(DatasetSnapshot, filter)
 }
 
 // Filesystems returns a slice of ZFS filesystems.
 // A filter argument may be passed to select a filesystem with the matching name,
 // or empty string ("") may be used to select all filesystems.
 func Filesystems(filter string) ([]*Dataset, error) {
-	return listByType("filesystem", filter)
+	return listByType(DatasetFilesystem, filter)
 }
 
 // Volumes returns a slice of ZFS volumes.
 // A filter argument may be passed to select a volume with the matching name,
 // or empty string ("") may be used to select all volumes.
 func Volumes(filter string) ([]*Dataset, error) {
-	return listByType("volume", filter)
+	return listByType(DatasetVolume, filter)
 }
 
 // GetDataset retrieves a single ZFS dataset by name.  This dataset could be
@@ -82,7 +90,7 @@ func GetDataset(name string) (*Dataset, error) {
 // Clone clones a ZFS snapshot and returns a clone dataset.
 // An error will be returned if the input dataset is not of snapshot type.
 func (d *Dataset) Clone(dest string, properties map[string]string) (*Dataset, error) {
-	if d.Type != "snapshot" {
+	if d.Type != DatasetSnapshot {
 		return nil, errors.New("can only clone snapshots")
 	}
 	args := make([]string, 2, 4)
@@ -114,7 +122,7 @@ func ReceiveSnapshot(input io.Reader, name string) (*Dataset, error) {
 // SendSnapshot sends a ZFS stream of a snapshot to the input io.Writer.
 // An error will be returned if the input dataset is not of snapshot type.
 func (d *Dataset) SendSnapshot(output io.Writer) error {
-	if d.Type != "snapshot" {
+	if d.Type != DatasetSnapshot {
 		return errors.New("can only send snapshots")
 	}
 
@@ -228,7 +236,7 @@ func (d *Dataset) Snapshot(name string, recursive bool) (*Dataset, error) {
 // snapshots exist.
 // An error will be returned if the input dataset is not of snapshot type.
 func (d *Dataset) Rollback(destroyMoreRecent bool) error {
-	if d.Type != "snapshot" {
+	if d.Type != DatasetSnapshot {
 		errors.New("can only rollback snapshots")
 	}
 

--- a/zfs_test.go
+++ b/zfs_test.go
@@ -76,7 +76,7 @@ func TestDatasets(t *testing.T) {
 
 		ds, err := zfs.GetDataset("test")
 		ok(t, err)
-		equals(t, "filesystem", ds.Type)
+		equals(t, zfs.DatasetFilesystem, ds.Type)
 	})
 }
 
@@ -87,7 +87,7 @@ func TestSnapshots(t *testing.T) {
 		ok(t, err)
 
 		for _, snapshot := range snapshots {
-			equals(t, "snapshot", snapshot.Type)
+			equals(t, zfs.DatasetSnapshot, snapshot.Type)
 		}
 	})
 }
@@ -101,7 +101,7 @@ func TestFilesystems(t *testing.T) {
 		ok(t, err)
 
 		for _, filesystem := range filesystems {
-			equals(t, "filesystem", filesystem.Type)
+			equals(t, zfs.DatasetFilesystem, filesystem.Type)
 		}
 
 		ok(t, f.Destroy(false))
@@ -123,7 +123,7 @@ func TestCreateFilesystemWithProperties(t *testing.T) {
 		ok(t, err)
 
 		for _, filesystem := range filesystems {
-			equals(t, "filesystem", filesystem.Type)
+			equals(t, zfs.DatasetFilesystem, filesystem.Type)
 		}
 
 		ok(t, f.Destroy(false))
@@ -138,12 +138,12 @@ func TestVolumes(t *testing.T) {
 		// volumes are sometimes "busy" if you try to manipulate them right away
 		sleep(1)
 
-		equals(t, "volume", v.Type)
+		equals(t, zfs.DatasetVolume, v.Type)
 		volumes, err := zfs.Volumes("")
 		ok(t, err)
 
 		for _, volume := range volumes {
-			equals(t, "volume", volume.Type)
+			equals(t, zfs.DatasetVolume, volume.Type)
 		}
 
 		ok(t, v.Destroy(false))
@@ -159,13 +159,13 @@ func TestSnapshot(t *testing.T) {
 		ok(t, err)
 
 		for _, filesystem := range filesystems {
-			equals(t, "filesystem", filesystem.Type)
+			equals(t, zfs.DatasetFilesystem, filesystem.Type)
 		}
 
 		s, err := f.Snapshot("test", false)
 		ok(t, err)
 
-		equals(t, "snapshot", s.Type)
+		equals(t, zfs.DatasetSnapshot, s.Type)
 
 		equals(t, "test/snapshot-test@test", s.Name)
 
@@ -184,19 +184,19 @@ func TestClone(t *testing.T) {
 		ok(t, err)
 
 		for _, filesystem := range filesystems {
-			equals(t, "filesystem", filesystem.Type)
+			equals(t, zfs.DatasetFilesystem, filesystem.Type)
 		}
 
 		s, err := f.Snapshot("test", false)
 		ok(t, err)
 
-		equals(t, "snapshot", s.Type)
+		equals(t, zfs.DatasetSnapshot, s.Type)
 		equals(t, "test/snapshot-test@test", s.Name)
 
 		c, err := s.Clone("test/clone-test", nil)
 		ok(t, err)
 
-		equals(t, "filesystem", c.Type)
+		equals(t, zfs.DatasetFilesystem, c.Type)
 
 		ok(t, c.Destroy(false))
 
@@ -215,7 +215,7 @@ func TestSendSnapshot(t *testing.T) {
 		ok(t, err)
 
 		for _, filesystem := range filesystems {
-			equals(t, "filesystem", filesystem.Type)
+			equals(t, zfs.DatasetFilesystem, filesystem.Type)
 		}
 
 		s, err := f.Snapshot("test", false)
@@ -244,7 +244,7 @@ func TestChildren(t *testing.T) {
 		s, err := f.Snapshot("test", false)
 		ok(t, err)
 
-		equals(t, "snapshot", s.Type)
+		equals(t, zfs.DatasetSnapshot, s.Type)
 		equals(t, "test/snapshot-test@test", s.Name)
 
 		children, err := f.Children(0)
@@ -274,7 +274,7 @@ func TestRollback(t *testing.T) {
 		ok(t, err)
 
 		for _, filesystem := range filesystems {
-			equals(t, "filesystem", filesystem.Type)
+			equals(t, zfs.DatasetFilesystem, filesystem.Type)
 		}
 
 		s1, err := f.Snapshot("test", false)


### PR DESCRIPTION
Closes #15.

I went with `DatasetFilesystem` instead of `TypeFilesystem` etc. to make it more obvious what the constants reference.
