### PR TITLE
Fix string split in command.Run(), use strings.Fields() instead of strin...

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -56,7 +56,7 @@ func (c *command) Run(arg ...string) ([][]string, error) {
 	output := make([][]string, len(lines))
 
 	for i, l := range lines {
-		output[i] = strings.Split(l, "\t")
+		output[i] = strings.Fields(l)
 	}
 
 	return output, nil


### PR DESCRIPTION
...gs.Split()

Fixes a panic on the `devel` branch, seen here in tests: https://gist.github.com/mdlayher/87bd542351268dbd6bb4

I believe the issue is that the command output contains whitespace characters which are not just tabs, and as a result, the input was not being split properly.

This appears to resolve the issue in the tests, as well as in my project.
