### PR TITLE
Fix Truncating First Zpool

### DIFF
--- a/zpool.go
+++ b/zpool.go
@@ -92,9 +92,6 @@ func ListZpools() ([]*Zpool, error) {
 		return nil, err
 	}
 
-	// there is no -H
-	out = out[1:]
-
 	var pools []*Zpool
 
 	for _, line := range out {


### PR DESCRIPTION
Header is not emitted by the the `zpool` command as `-H` flag is given, this line in effect removes the first zpool from the array.