### PR TITLE
zfs command uses different order of arguments on freebsd

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -264,7 +264,7 @@ func parseInodeChanges(lines [][]string) ([]*InodeChange, error) {
 }
 
 func listByType(t, filter string) ([]*Dataset, error) {
-	args := []string{"get", "all", "-t", t, "-rHp"}
+	args := []string{"get", "-rHp", "-t", t, "all"}
 	if filter != "" {
 		args = append(args, filter)
 	}

--- a/zfs.go
+++ b/zfs.go
@@ -137,7 +137,7 @@ func Volumes(filter string) ([]*Dataset, error) {
 // GetDataset retrieves a single ZFS dataset by name.  This dataset could be
 // any valid ZFS dataset type, such as a clone, filesystem, snapshot, or volume.
 func GetDataset(name string) (*Dataset, error) {
-	out, err := zfs("get", "all", "-Hp", name)
+	out, err := zfs("get", "-Hp", "all", name)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (d *Dataset) Rollback(destroyMoreRecent bool) error {
 // A recursion depth may be specified, or a depth of 0 allows unlimited
 // recursion.
 func (d *Dataset) Children(depth uint64) ([]*Dataset, error) {
-	args := []string{"get", "all", "-t", "all", "-Hp"}
+	args := []string{"get", "-t", "all", "-Hp", "all"}
 	if depth > 0 {
 		args = append(args, "-d")
 		args = append(args, strconv.FormatUint(depth, 10))


### PR DESCRIPTION
On FreeBSD options for zfs command should follow command name, like "zfs get -t all dataset"

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mistifyio/go-zfs/32)
<!-- Reviewable:end -->
