### PR TITLE
Remove command name from debug message joinedArgs

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -48,7 +48,7 @@ func (c *command) Run(arg ...string) ([][]string, error) {
 	if err != nil {
 		return nil, &Error{
 			Err:    err,
-			Debug:  strings.Join([]string{cmd.Path, joinedArgs}, " "),
+			Debug:  strings.Join([]string{cmd.Path, joinedArgs[1:]}, " "),
 			Stderr: stderr.String(),
 		}
 	}


### PR DESCRIPTION
Remove command name from joinedArgs as path to command is already printed (making it confusing to debug)

```
encountered error getting children of zfs filesystem: zpool_default/docker: exit status 1: "/usr/sbin/zfs get -t all -Hp all -r zpool_default/docker" => cannot open '-r': dataset does not exist
encountered error refreshing zfs watcher: exit status 1: "/usr/sbin/zfs get -t all -Hp all -r zpool_default/docker" => cannot open '-r': dataset does not exist
```

Instead of:
```
encountered error getting children of zfs filesystem: zpool_default/docker: exit status 1: "/usr/sbin/zfs zfs get -t all -Hp all -r zpool_default/docker" => cannot open '-r': dataset does not exist
encountered error refreshing zfs watcher: exit status 1: "/usr/sbin/zfs zfs get -t all -Hp all -r zpool_default/docker" => cannot open '-r': dataset does not exist
```


