### PR TITLE
Issue #62 - Return parsable property

### DIFF
--- a/zfs.go
+++ b/zfs.go
@@ -308,7 +308,7 @@ func (d *Dataset) SetProperty(key, val string) error {
 // A full list of available ZFS properties may be found here:
 // https://www.freebsd.org/cgi/man.cgi?zfs(8).
 func (d *Dataset) GetProperty(key string) (string, error) {
-	out, err := zfs("get", "-H", key, d.Name)
+	out, err := zfs("get", "-p", "-H", key, d.Name)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This pull request resolves problem described in issue #62 with non-parsable output of some properties (especially size related).