### PR TITLE
split after \t instead of any spaces

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -61,7 +61,7 @@ func (c *command) Run(arg ...string) ([][]string, error) {
 	output := make([][]string, len(lines))
 
 	for i, l := range lines {
-		output[i] = strings.Fields(l)
+		output[i] = strings.Split(l, "\t")
 	}
 
 	return output, nil

--- a/utils_notsolaris.go
+++ b/utils_notsolaris.go
@@ -15,5 +15,5 @@ var (
 	zpoolPropList = []string{"name", "health", "allocated", "size", "free", "readonly", "dedupratio", "fragmentation", "freeing", "leaked"}
 
 	zpoolPropListOptions = strings.Join(zpoolPropList, ",")
-	zpoolArgs            = []string{"get", "-p", zpoolPropListOptions}
+	zpoolArgs            = []string{"get", "-Hp", zpoolPropListOptions}
 )

--- a/utils_solaris.go
+++ b/utils_solaris.go
@@ -15,5 +15,5 @@ var (
 	zpoolPropList = []string{"name", "health", "allocated", "size", "free", "readonly", "dedupratio"}
 
 	zpoolPropListOptions = strings.Join(zpoolPropList, ",")
-	zpoolArgs            = []string{"get", "-p", zpoolPropListOptions}
+	zpoolArgs            = []string{"get", "-Hp", zpoolPropListOptions}
 )

--- a/zfs_test.go
+++ b/zfs_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	zfs "github.com/mistifyio/go-zfs/v3"
@@ -38,6 +39,13 @@ func TestDatasetGetProperty(t *testing.T) {
 	prop, err = ds.GetProperty("compression")
 	ok(t, err)
 	equals(t, "off", prop)
+
+	// creation should be a time stamp with spaces in it
+	prop, err = ds.GetProperty("creation")
+	ok(t, err)
+	if len(strings.Fields(prop)) != 5 {
+		t.Errorf("expected a string with spaces in it, got: %v", prop)
+	}
 }
 
 func TestSnapshots(t *testing.T) {

--- a/zpool.go
+++ b/zpool.go
@@ -49,9 +49,6 @@ func GetZpool(name string) (*Zpool, error) {
 		return nil, err
 	}
 
-	// there is no -H
-	out = out[1:]
-
 	z := &Zpool{Name: name}
 	for _, line := range out {
 		if err := z.parseLine(line); err != nil {


### PR DESCRIPTION
Without this dates like (Wed Feb 21 12:51 2018) in the creation property are split into multiple fields