### PR TITLE
Add go.mod and rename to github.com/mistifyio/go-zfs/v3 (v3.0.0)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/mistifyio/go-zfs/v3
+
+go 1.14
+
+require github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/zfs_test.go
+++ b/zfs_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	zfs "github.com/mistifyio/go-zfs"
+	zfs "github.com/mistifyio/go-zfs/v3"
 )
 
 func sleep(delay int) {


### PR DESCRIPTION
This adds a go.mod to this project, and updates the module name to v3.
Go modules expect modules with version v2.0.0 or above to include the
major version in the module name, and otherwise won't be able to use
the module. Currently, this still works because the project does not
have a `go.mod`, which means that go modules will "allow" invalid
module names, and add a `+incompatible` comment to the version.

Given that this project already reached `v2.0.0`, and renaming the module
is a breaking change, this change requires an update to the major version
(to follow SemVer), thus renaming to `v3` and, if a new release is to be
tagged, to be released as `v3.0.0`.