### PR TITLE
Add functions to send a (incremental) snapshot encrypted

### DIFF
--- a/zfs.go
+++ b/zfs.go
@@ -239,6 +239,18 @@ func (d *Dataset) SendSnapshot(output io.Writer) error {
 	return err
 }
 
+// SendSnapshotRaw sends an encrypted ZFS stream of a snapshot to the input io.Writer.
+// An error will be returned if the input dataset is not of snapshot type.
+func (d *Dataset) SendSnapshotRaw(output io.Writer) error {
+	if d.Type != DatasetSnapshot {
+		return errors.New("can only send snapshots")
+	}
+
+	c := command{Command: "zfs", Stdout: output}
+	_, err := c.Run("send", "-w", d.Name)
+	return err
+}
+
 // IncrementalSend sends a ZFS stream of a snapshot to the input io.Writer using the baseSnapshot as the starting point.
 // An error will be returned if the input dataset is not of snapshot type.
 func (d *Dataset) IncrementalSend(baseSnapshot *Dataset, output io.Writer) error {
@@ -247,6 +259,17 @@ func (d *Dataset) IncrementalSend(baseSnapshot *Dataset, output io.Writer) error
 	}
 	c := command{Command: "zfs", Stdout: output}
 	_, err := c.Run("send", "-i", baseSnapshot.Name, d.Name)
+	return err
+}
+
+// IncrementalRawSend sends an encrypted ZFS stream of a snapshot to the input io.Writer using the baseSnapshot as the starting point.
+// An error will be returned if the input dataset is not of snapshot type.
+func (d *Dataset) IncrementalRawSend(baseSnapshot *Dataset, output io.Writer) error {
+	if d.Type != DatasetSnapshot || baseSnapshot.Type != DatasetSnapshot {
+		return errors.New("can only send snapshots")
+	}
+	c := command{Command: "zfs", Stdout: output}
+	_, err := c.Run("send", "-w", "-i", baseSnapshot.Name, d.Name)
 	return err
 }
 


### PR DESCRIPTION
Hello!

I am looking to start using this library for managing zfs. I am however looking to apply native zfs encryption to my datasets. In order to also encrypt the [zfs send](https://openzfs.github.io/openzfs-docs/man/8/zfs-send.8.html) datastream, I should set the `-w` (or `--raw`) flag to zfs send, see:

> For encrypted datasets, send data exactly as it exists on disk. This allows backups to be taken even if encryption keys are not currently loaded. The backup may then be received on an untrusted machine since that machine will not have the encryption keys to read the protected data or alter it without being detected. Upon being received, the dataset will have the same encryption keys as it did on the send side, although the keylocation property will be defaulted to prompt if not otherwise provided. For unencrypted datasets, this flag will be equivalent to -Lec. Note that if you do not use this flag for sending encrypted datasets, data will be sent unencrypted and may be re-encrypted with a different encryption key on the receiving system, which will disable the ability to do a raw send to that system for incrementals.

This PR adds the functions `SendSnapshotRaw` and `IncrementalRawSend` which add this flag.

Let me know if you'd rather see this change take a different form or any other ideas/suggestions!

