### PR TITLE
Use nix-env in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,14 +21,14 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixpkgs-unstable
 
-      - name: Fetch Nix Derivations
-        run: nix-shell --command true
+      - name: Install Nix Packages
+        run: nix-env -f shell.nix -i -A buildInputs
 
       - name: Install Go tools
-        run: nix-shell --run 'make tools'
+        run: make tools
 
       - name: Linters and Go Formatting
-        run: nix-shell --run 'make verify'
+        run: make verify
 
       - name: Non Go Formatters
         run: ./.github/workflows/formatters.sh
@@ -37,4 +37,4 @@ jobs:
         run: sudo apt-get -y update && sudo apt-get -y install zfsutils-linux
 
       - name: Tests
-        run: nix-shell --run 'sudo make test'
+        run: sudo make test

--- a/.github/workflows/formatters.sh
+++ b/.github/workflows/formatters.sh
@@ -1,6 +1,4 @@
-#!/usr/bin/env nix-shell
-#!nix-shell -i bash ../../shell.nix
-#shellcheck shell=bash
+#!/usr/bin/env bash
 
 set -eux
 

--- a/.github/workflows/formatters.sh
+++ b/.github/workflows/formatters.sh
@@ -18,6 +18,10 @@ if ! nixfmt shell.nix; then
 	failed=1
 fi
 
+if ! rufo Vagrantfile; then
+	failed=1
+fi
+
 if ! git diff | (! grep .); then
 	failed=1
 fi

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,13 +1,12 @@
-
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-    config.vm.box = "ubuntu/trusty64"
-	config.ssh.forward_agent = true
+  config.vm.box = "ubuntu/trusty64"
+  config.ssh.forward_agent = true
 
-	config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/mistifyio/go-zfs", create: true
+  config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/mistifyio/go-zfs", create: true
 
-    config.vm.provision "shell", inline: <<EOF
+  config.vm.provision "shell", inline: <<EOF
 cat << END > /etc/profile.d/go.sh
 export GOPATH=\\$HOME/go
 export PATH=\\$GOPATH/bin:/usr/local/go/bin:\\$PATH
@@ -30,5 +29,4 @@ Defaults env_keep += "GOPATH"
 END
 
 EOF
-
 end

--- a/shell.nix
+++ b/shell.nix
@@ -19,6 +19,7 @@ mkShell {
     nodePackages.prettier
     python3Packages.pip
     python3Packages.setuptools
+    rufo
     shfmt
     vagrant
   ];


### PR DESCRIPTION
Somehow I didn't think to use nix-env in CI until reading a snippet of someone doing so in a hackernew or mabye lobste.rs comment. This makes it so much nicer to use imo. I also got rid of the nix-shell in the formatters.sh shebang to make it more useful for users, no need to tie it to nix-shell and make it hard/unusable to people when CI will catch any diffs due to different tool versions.