### PR TITLE
Add -p flag in GetProperty in order to display numbers in parsable values

### DIFF
--- a/zfs.go
+++ b/zfs.go
@@ -312,7 +312,7 @@ func (d *Dataset) SetProperty(key, val string) error {
 // A full list of available ZFS properties may be found in the ZFS manual:
 // https://openzfs.github.io/openzfs-docs/man/7/zfsprops.7.html.
 func (d *Dataset) GetProperty(key string) (string, error) {
-	out, err := zfsOutput("get", "-H", key, d.Name)
+	out, err := zfsOutput("get", "-Hp", key, d.Name)
 	if err != nil {
 		return "", err
 	}

--- a/zfs_test.go
+++ b/zfs_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
+	"strconv"
 	"testing"
 
 	zfs "github.com/mistifyio/go-zfs/v3"
@@ -40,11 +40,13 @@ func TestDatasetGetProperty(t *testing.T) {
 	ok(t, err)
 	equals(t, "on", prop)
 
-	// creation should be a time stamp with spaces in it
+	// creation should be a numeric timestamp
 	prop, err = ds.GetProperty("creation")
 	ok(t, err)
-	if len(strings.Fields(prop)) != 5 {
-		t.Errorf("expected a string with spaces in it, got: %v", prop)
+
+	_, err = strconv.ParseInt(prop, 10, 64)
+	if err != nil {
+		t.Errorf("expected a numeric timestamp, got: %v", prop)
 	}
 }
 


### PR DESCRIPTION
It seems that -p flag is missing from GetProperty.
I can see that it is passed anywhere else.
With this pr the parsable values of numbers are returned from GetProperty also.