### PR TITLE
mergify: Remove ready-to-merge label when PR is closed

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -21,3 +21,11 @@ pull_request_rules:
           {{ title }} (#{{ number }})
 
           {{ body }}
+
+  - name: remove ready-to-merge label when no longer needed
+    conditions:
+      - closed
+    actions:
+      label:
+        remove:
+          - ready-to-merge


### PR DESCRIPTION
This way the ready-to-merge label can be used to filter PRs that are stalled.
Mergify considers a merged PR closed, so we don't need to add it explicitly.