### PR TITLE
test: Update ZoL default to compression=on

### DIFF
--- a/zfs_test.go
+++ b/zfs_test.go
@@ -38,7 +38,7 @@ func TestDatasetGetProperty(t *testing.T) {
 
 	prop, err = ds.GetProperty("compression")
 	ok(t, err)
-	equals(t, "off", prop)
+	equals(t, "on", prop)
 
 	// creation should be a time stamp with spaces in it
 	prop, err = ds.GetProperty("creation")


### PR DESCRIPTION
Looks like the zfs tests are failing now due to `compression=on` being a new default for our ZoL package.